### PR TITLE
Preload unsorted.txt in the scratchpad for the files exercise

### DIFF
--- a/tested/files/config.json
+++ b/tested/files/config.json
@@ -3,7 +3,10 @@
     "names": {
       "en": "Sort",
       "nl": "Sorteren"
-    }
+    },
+    "sandbox_files": [
+      "unsorted.txt"
+    ]
   },
   "evaluation": {
     "handler": "tested",

--- a/tested/files/description/description.en.md
+++ b/tested/files/description/description.en.md
@@ -5,7 +5,7 @@ Write a Python program that accepts two arguments:
 
 The program should read the content of the source file, sort it, and write the sorted content to the destination file. If the destination file does not exist, it should be created; otherwise, it should be overwritten.
 
-Click the file [`unsorted.txt`](media/unsorted.txt) to open it. In the sandbox you can also drag it: a dropzone appears where you can drop it to open it in the editor.
+Click the file [`unsorted.txt`](media/unsorted.txt) to open it.
 
 ### Example
 

--- a/tested/files/description/description.en.md
+++ b/tested/files/description/description.en.md
@@ -5,8 +5,6 @@ Write a Python program that accepts two arguments:
 
 The program should read the content of the source file, sort it, and write the sorted content to the destination file. If the destination file does not exist, it should be created; otherwise, it should be overwritten.
 
-Click the file [`unsorted.txt`](media/unsorted.txt) to open it.
-
 ### Example
 
 ```console

--- a/tested/files/description/description.nl.md
+++ b/tested/files/description/description.nl.md
@@ -8,7 +8,7 @@ en de gesorteerde inhoud uitschrijven naar het doelbestand.
 Als het doelbestand nog niet bestaat moet het aangemaakt worden,
 anders moet het overschreven worden.
 
-Klik op het bestand [`unsorted.txt`](media/unsorted.txt) om het te openen. In de sandbox kan je het ook slepen: er verschijnt dan een dropzone waar je het kan laten vallen om het in de editor te openen.
+Klik op het bestand [`unsorted.txt`](media/unsorted.txt) om het te openen.
 
 ### Voorbeeld
 

--- a/tested/files/description/description.nl.md
+++ b/tested/files/description/description.nl.md
@@ -8,8 +8,6 @@ en de gesorteerde inhoud uitschrijven naar het doelbestand.
 Als het doelbestand nog niet bestaat moet het aangemaakt worden,
 anders moet het overschreven worden.
 
-Klik op het bestand [`unsorted.txt`](media/unsorted.txt) om het te openen.
-
 ### Voorbeeld
 
 ```console


### PR DESCRIPTION
Adds a `sandbox_files` key under the `description` object in the `tested/files` exercise config, set to `["unsorted.txt"]`. This is the new config option introduced in dodona-edu/dodona#8249, which preloads the listed files (resolved under `description/media/`) into the scratchpad the moment it's opened.

Since the file now loads automatically, I also dropped the line telling students to open `unsorted.txt` (both the click-to-open and the drag-and-drop hint) from the EN and NL descriptions.

## Manual testing

- Reprocess the repository on an instance running dodona-edu/dodona#8249
- Open the `tested/files` (Sort) exercise and open the scratchpad
- Once loading finishes, `unsorted.txt` is preloaded in the editor

Depends on dodona-edu/dodona#8249 (the config key is only read once that's merged and deployed).